### PR TITLE
perf: 人口構成データをキャッシュする

### DIFF
--- a/app/components/PopuTrackPane.tsx
+++ b/app/components/PopuTrackPane.tsx
@@ -1,14 +1,17 @@
 "use client";
 
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 import { ChartPane } from "./ChartPane";
 import { CheckBoxPane } from "./CheckBoxPane";
 
+const queryClient = new QueryClient();
+
 export const PopuTrackPane: React.FC = () => {
   return (
-    <>
+    <QueryClientProvider client={queryClient}>
       <CheckBoxPane />
       <ChartPane />
-    </>
+    </QueryClientProvider>
   );
 };

--- a/app/hooks/usePrefecturesPopulationData.ts
+++ b/app/hooks/usePrefecturesPopulationData.ts
@@ -1,6 +1,7 @@
 import { PrefectureWithPopulationComposition } from "@/app/types";
 
 import { getPrefecturePopulationCompositionData } from "@/app/lib/api";
+import { useQueryClient } from "@tanstack/react-query";
 import { atom, useAtom } from "jotai";
 import { useCallback } from "react";
 import { useCheckedPrefectures } from "./useCheckedPrefectures";
@@ -13,6 +14,8 @@ const isLoadingAtom = atom<boolean>(false);
 const errorAtom = atom<Error | null>(null);
 
 export const usePrefecturesPopulationData = () => {
+  const queryClient = useQueryClient();
+
   const { prefectures } = usePrefectures();
   const { checkedPrefectures, setCheckedPrefectures } = useCheckedPrefectures();
 
@@ -43,7 +46,10 @@ export const usePrefecturesPopulationData = () => {
           setIsLoading(true);
 
           const newPrefectureCompositionData =
-            await getPrefecturePopulationCompositionData(prefectures[prefIdx]);
+            await getPrefecturePopulationCompositionData(
+              queryClient,
+              prefectures[prefIdx],
+            );
 
           setPrefecturesPopulationCompositionData([
             ...prefecturesPopulationCompositionData,
@@ -52,6 +58,7 @@ export const usePrefecturesPopulationData = () => {
 
           setCheckedPrefectures([...checkedPrefectures, prefIdx]);
         } catch (error) {
+          console.error(error);
           setError(error as Error);
         } finally {
           setIsLoading(false);

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -3,6 +3,7 @@ import {
   Prefecture,
   PrefectureWithPopulationComposition,
 } from "@/app/types";
+import { QueryClient } from "@tanstack/react-query";
 import axios from "axios";
 
 const POPULATION_TOTAL = "総人口";
@@ -11,13 +12,19 @@ const POPULATION_PRODUCTIVE = "生産年齢人口";
 const POPULATION_ELDERLY = "老年人口";
 
 export async function getPrefecturePopulationCompositionData(
+  queryClient: QueryClient,
   prefecture: Prefecture,
 ): Promise<PrefectureWithPopulationComposition> {
-  const populationComposition: PopulationCompositionAPIResponse = await axios
-    .get(`/api/population/composition/perYear?prefCode=${prefecture.prefCode}`)
-    .then((res) => res.data.result)
-    .catch(() => {
-      throw new Error("人口構成データの取得に失敗しました");
+  const populationComposition: PopulationCompositionAPIResponse =
+    await queryClient.fetchQuery({
+      queryKey: ["populationComposition", prefecture.prefCode],
+      queryFn: async () => {
+        const response = await axios.get(
+          `/api/population/composition/perYear?prefCode=${prefecture.prefCode}`,
+        );
+        return response.data.result;
+      },
+      staleTime: 1000 * 60 * 60 * 1,
     });
 
   return {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@emotion/react": "^11.11.4",
     "@heroicons/react": "^2.1.3",
     "@tanstack/query-core": "^5.62.15",
+    "@tanstack/react-query": "^5.62.15",
     "axios": "^1.6.8",
     "highcharts": "^11.4.1",
     "highcharts-react-official": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -364,10 +364,17 @@
     "@swc/counter" "^0.1.3"
     tslib "^2.4.0"
 
-"@tanstack/query-core@^5.62.15":
+"@tanstack/query-core@5.62.15", "@tanstack/query-core@^5.62.15":
   version "5.62.15"
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.62.15.tgz#ded0267ac31bd23f3c45ffc008dba85a25621e91"
   integrity sha512-wT20X14CxcWY8YLJ/1pnsXn/y1Q2uRJZYWW93PWRtZt+3/JlGZyiyTcO4pGnqycnP7CokCROAyatsraosqZsDA==
+
+"@tanstack/react-query@^5.62.15":
+  version "5.62.15"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.62.15.tgz#ecfe7187913e36c36630afedf4f8eff37247c400"
+  integrity sha512-Ny3xxsOWmEQCFyHiV3CF7t6+QAV+LpBEREiXyllKR4+tStyd8smOAa98ZHmEx0ZNy36M31K8enifB5wTSYAKJw==
+  dependencies:
+    "@tanstack/query-core" "5.62.15"
 
 "@types/estree@^1.0.6":
   version "1.0.6"


### PR DESCRIPTION
- tanstack query を使用して、都道府県別の人口構成データをキャッシュする
- 例えば、「東京都」にチェックを入れる→チェックを外す→チェックを入れる、という操作をしたとき、2回目にチェックをいれたときはキャッシュのデータを利用する